### PR TITLE
Remove ssh procedure from the github action

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -62,12 +62,3 @@ jobs:
           echo "Push image to ECR"
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-
-      - name: SSH to ec2
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.HOST }}
-          username: ${{ secrets.SSH_USERNAME }}
-          key: ${{ secrets.SSH_KEY }}
-          port: ${{ secrets.APP_HH_PORT }}
-          script: whoami


### PR DESCRIPTION
在 github action 有動態 ip 的情況, 使得設定 aws security group 變的不太實際, 故為了安全性決定不使用 ssh into instance to deploy 的方式作部署